### PR TITLE
Feat: refresh menu nutrition endpoint

### DIFF
--- a/app/src/controller/menu-controller.ts
+++ b/app/src/controller/menu-controller.ts
@@ -6,6 +6,7 @@ import {
   GetMenuDetailRequest,
   GetMenuRecipeRequest,
   GetMenuRecipeResponse,
+  RefreshMenuNutritionRequest,
   SearchMenuRequest,
   SetMenuRecipeRequest,
   UpdateMenuApprovalRequest,
@@ -16,6 +17,7 @@ import { ImageUploaderService } from '../service/image-uploader-service';
 import { MenuService } from '../service/menu-service';
 import { RecipeService } from '../service/recipe-service';
 import { UserRequest } from '../type/user';
+import { Menu } from '@prisma/client';
 import { NextFunction, Response } from 'express';
 
 export class MenuController {
@@ -281,6 +283,34 @@ export class MenuController {
       res.status(200).json({
         message: 'Success!',
         data: response,
+      });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async refreshMenuNutrition(
+    req: UserRequest,
+    res: Response,
+    next: NextFunction
+  ) {
+    try {
+      const requestRole = String(req.user.role);
+
+      const requestRestaurantId =
+        requestRole === 'Restoran'
+          ? String(req.user.id)
+          : String(req.params.restaurantId);
+
+      const request: RefreshMenuNutritionRequest = {
+        restaurant_id: requestRestaurantId,
+        menu_id: Number(req.params.menuId),
+      };
+
+      const menu: Menu = await RecipeService.refreshMenuNutrition(request);
+
+      res.status(200).json({
+        message: `Berhasil memperbarui nutrisi dari menu ${menu.name}`,
       });
     } catch (e) {
       next(e);

--- a/app/src/model/menu-model.ts
+++ b/app/src/model/menu-model.ts
@@ -181,6 +181,11 @@ export type SetMenuRecipeRequest = {
   items: RecipeItemInput[];
 };
 
+export type RefreshMenuNutritionRequest = {
+  restaurant_id: string;
+  menu_id: number;
+};
+
 export function toAllMenusResponse(menu: Menu): AllMenusResponse {
   return {
     id: menu.id,

--- a/app/src/route/private-api.ts
+++ b/app/src/route/private-api.ts
@@ -199,6 +199,11 @@ privateRouter.get(
   authorizeMiddleware(Roles.AdminAndRestaurant),
   MenuController.getMenuRecipe
 );
+privateRouter.patch(
+  '/api/restaurants/:restaurantId([a-zA-Z0-9_-]+)/menus/:menuId(\\d+)/recipe',
+  authorizeMiddleware(Roles.AdminAndRestaurant),
+  MenuController.refreshMenuNutrition
+);
 
 // Order Module
 privateRouter.post(

--- a/app/src/service/recipe-service.ts
+++ b/app/src/service/recipe-service.ts
@@ -324,7 +324,7 @@ export class RecipeService {
     request: RefreshMenuNutritionRequest
   ): Promise<Menu> {
     const payload: RefreshMenuNutritionRequest = Validation.validate(
-      RecipeValidation.REFRESH,
+      RecipeValidation.REFRESHNUTRITION,
       request
     );
 

--- a/app/src/service/recipe-service.ts
+++ b/app/src/service/recipe-service.ts
@@ -3,6 +3,7 @@ import { ResponseError } from '../error/response-error';
 import {
   GetMenuRecipeRequest,
   GetMenuRecipeResponse,
+  RefreshMenuNutritionRequest,
   SetMenuRecipeRequest,
 } from '../model/menu-model';
 import { RecipeValidation } from '../validation/recipe-validation';
@@ -317,5 +318,25 @@ export class RecipeService {
       menu_name: menu.name,
       items: items,
     } as GetMenuRecipeResponse;
+  }
+
+  static async refreshMenuNutrition(
+    request: RefreshMenuNutritionRequest
+  ): Promise<Menu> {
+    const payload: RefreshMenuNutritionRequest = Validation.validate(
+      RecipeValidation.REFRESH,
+      request
+    );
+
+    const menu: Menu = await MenuService.checkMenuExist(
+      payload.menu_id,
+      payload.restaurant_id
+    );
+
+    await prismaClient.$transaction(async (tx: Prisma.TransactionClient) => {
+      await this.recalculateNutritionInternal(tx, payload.menu_id);
+    });
+
+    return menu;
   }
 }

--- a/app/src/validation/recipe-validation.ts
+++ b/app/src/validation/recipe-validation.ts
@@ -19,4 +19,13 @@ export class RecipeValidation {
       )
       .default([]),
   });
+
+  static readonly REFRESH: ZodType = z.object({
+    restaurant_id: z
+      .string()
+      .trim()
+      .min(38, 'ID restoran tidak valid')
+      .max(38, 'ID restoran tidak valid'),
+    menu_id: z.number().positive('Menu ID harus bernilai positif'),
+  });
 }

--- a/app/src/validation/recipe-validation.ts
+++ b/app/src/validation/recipe-validation.ts
@@ -20,7 +20,7 @@ export class RecipeValidation {
       .default([]),
   });
 
-  static readonly REFRESH: ZodType = z.object({
+  static readonly REFRESHNUTRITION: ZodType = z.object({
     restaurant_id: z
       .string()
       .trim()


### PR DESCRIPTION
Updating nutrition values in MasterBahan or MasterBumbu (e.g., calories, protein, fat, etc.) did not trigger recalculation for menus that included those items in their recipes. As a result, menu-level nutrition information became outdated and incorrect.

This new update ensures that whenever a MasterBahan or MasterBumbu is updated, 
user can fetch this PATCH endpoint and all related menus automatically recalculate and persist their nutrition totals based on the new values.

PATCH /api/restaurants/:restaurant_id/menus/:menu_id/recipe